### PR TITLE
Improve CRT video timings to better comply with the standard 640x400@70Hz...

### DIFF
--- a/rtl/vga.v
+++ b/rtl/vga.v
@@ -249,7 +249,7 @@ module VGA_CRT(
 		if(ce_vga) begin
 			hcount <= hcount + 1'd1;
 			if (hch_en) begin
-				if (hchar == htotal + 4'd5) begin
+				if (hchar == htotal + 4'd4) begin
 					hcount <= 0;
 					hblnk <= 0;
 					hsync <= 0;
@@ -264,14 +264,14 @@ module VGA_CRT(
 	// This logic describes a 10-bit vertical position counter.         //
 	//******************************************************************//
 	always @(posedge clk_vga)
-		if(ce_vga && hch_en && hchar == htotal + 4'd5) begin
+		if(ce_vga && hch_en && hchar == htotal + 4'd4) begin
 			vcount <= vcount + 1'd1;
 			char_ln <= char_ln + 1'd1;
 			if (char_ln == replncnt) begin
 				char_ln <= 0;
 				char_row <= char_row + 1'd1;
 			end
-			if (vcount == vtotal) begin
+			if (vcount == vtotal + 4'd1) begin
 				char_ln <= line_preset;
 				vcount <= 0;
 				vblnk <= 0;


### PR DESCRIPTION
… video mode

- The 640x400@70Hz specification found in:
[VGA specification for 640x400@70Hz](http://tinyvga.com/vga-timing/640x400@70Hz)

Indicates that the Horizontal back porch + horizontal front porch pixel clock cycles should total 64 pixel clock cycles and each scanline should have a total of 800 pixel clock cycles per line and it should have 449 vertical lines in total.
- However when measuring the Next186 video signal in text mode with Norton Commander loaded we get the following:
```
python3 RGBClient.py --op=read --vidclk=25.17e6
b'R'b'1,58600,060,0650,280,190,1c0,2c8,044,020,004,00e,0ff,022,044,1e3,2c8\r\n'b'ACK\r\n'
Print pixel DataEnable signal was available
Frame time: 361984 pixel clock cycles, or 0.014 s per frame, or 69.533 fps.
Horizontal sync: 96 pixel clock cycles, or 0.000003814s
Vertical sync: 1616 pixel clock cycles, or 0.000064203s
Image pixels per line with pixel DataEnable signal active: 640 scanlines
Image pixel lines: 400 scanlines
Total frame lines: 448 scanlines
Total scanline length without horizontal sync.: 712 video clock cycles
Horizontal Back Porch: 68 video clock cycles, or 0.000002702s
Horizontal Front Porch: 4 video clock cycles, or 0.000000159s
Vertical Front Porch: 14 scanlines, or 0.000396027s
Vertical Back Porch: 32 scanlines, or 0.000905205s
...
------------------------
--- Other statistics ---
------------------------
Vertical sync: 2.000 lines.
Frame: 448.000 total scanlines.
Ok
```
when measured with the: [RGB signal generator and analyzer core](https://github.com/CoreRasurae/FPGA_DVITester)

- From which we can see that the current version of Next186 is generating:
1. 68+4=72 pixel clock cycles instead of 64 pixel clock cycles, thus resulting in scanlines having a width of 808 clock cycles
2. and it has 448 scanlines instead of 449

- With the corrections in this pull request we correct that to be:
```
Print pixel DataEnable signal was available
Frame time: 359200 pixel clock cycles.
Horizontal sync: 96 pixel clock cycles.
Vertical sync: 1600 pixel clock cycles.
Image pixels per line with pixel DataEnable signal active: 640 pixel clock cycles/pixels
Image pixel lines: 400 scanlines
Total frame lines: 449 scanlines
Total scanline length without horizontal sync.: 704 video clock cycles
Horizontal Back Porch: 60 video clock cycles.
Horizontal Front Porch: 4 video clock cycles.
Vertical Front Porch: 14 scanlines.
Vertical Back Porch: 33 scanlines.
------------------------
--- Other statistics ---
------------------------
Vertical sync: 2.000 lines.
Frame: 449.000 total scanlines.
Ok
```